### PR TITLE
Issue #5: add rho-agent websocket server transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +146,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -171,6 +235,41 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -298,6 +397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +497,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -595,10 +711,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -837,11 +965,13 @@ dependencies = [
 name = "rho-agent"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "futures",
  "futures-util",
  "rho-core",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -973,6 +1103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1123,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1117,7 +1269,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1128,6 +1292,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1156,6 +1332,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1194,6 +1371,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1212,6 +1390,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -1238,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1455,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/crates/rho-agent/Cargo.toml
+++ b/crates/rho-agent/Cargo.toml
@@ -6,9 +6,11 @@ license.workspace = true
 
 [dependencies]
 rho-core = { path = "../rho-core" }
+axum = { version = "0.8.6", features = ["ws"] }
 futures-util.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 futures = "0.3.31"

--- a/crates/rho-agent/src/lib.rs
+++ b/crates/rho-agent/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod runtime;
+pub mod server;
 
 pub use runtime::{AgentError, AgentRuntime, AgentSession};
+pub use server::{AgentServer, AgentServerError, build_provider};

--- a/crates/rho-agent/src/runtime.rs
+++ b/crates/rho-agent/src/runtime.rs
@@ -68,21 +68,44 @@ impl AgentRuntime {
         model: impl Into<String>,
         user_content: impl Into<String>,
     ) -> Result<Vec<ServerEvent>, AgentError> {
+        let model = model.into();
+        let user_content = user_content.into();
+        let mut emitted_events = Vec::new();
+        self.run_user_message_streaming(session, provider, model, user_content, |event| {
+            emitted_events.push(event);
+        })
+        .await?;
+        Ok(emitted_events)
+    }
+
+    pub async fn run_user_message_streaming<F>(
+        &self,
+        session: &mut AgentSession,
+        provider: &dyn Provider,
+        model: impl Into<String>,
+        user_content: impl Into<String>,
+        mut emit_event: F,
+    ) -> Result<(), AgentError>
+    where
+        F: FnMut(ServerEvent),
+    {
         session
             .messages
-            .push(Message::new(MessageRole::User, user_content));
-        self.run_completion_loop(session, provider, &model.into())
+            .push(Message::new(MessageRole::User, user_content.into()));
+        self.run_completion_loop(session, provider, &model.into(), &mut emit_event)
             .await
     }
 
-    async fn run_completion_loop(
+    async fn run_completion_loop<F>(
         &self,
         session: &mut AgentSession,
         provider: &dyn Provider,
         model: &str,
-    ) -> Result<Vec<ServerEvent>, AgentError> {
-        let mut emitted_events = Vec::new();
-
+        emit_event: &mut F,
+    ) -> Result<(), AgentError>
+    where
+        F: FnMut(ServerEvent),
+    {
         for iteration in 0..=self.max_tool_iterations {
             let request = ProviderRequest::new(model.to_string(), session.messages.clone());
             let mut stream = provider.stream(request);
@@ -95,26 +118,26 @@ impl AgentRuntime {
                 match next_event? {
                     ProviderEvent::AssistantDelta { delta } => {
                         assistant_delta_text.push_str(&delta);
-                        emitted_events.push(ServerEvent::AssistantDelta(AssistantDelta {
+                        emit_event(ServerEvent::AssistantDelta(AssistantDelta {
                             session_id: session.id.clone(),
                             delta,
                         }));
                     }
                     ProviderEvent::ToolCall { call } => {
-                        emitted_events.push(ServerEvent::ToolStarted(ToolStarted {
+                        emit_event(ServerEvent::ToolStarted(ToolStarted {
                             session_id: session.id.clone(),
                             call: call.clone(),
                         }));
 
                         let result = execute_builtin_tool(&call);
-                        emitted_events.push(ServerEvent::ToolCompleted(ToolCompleted {
+                        emit_event(ServerEvent::ToolCompleted(ToolCompleted {
                             session_id: session.id.clone(),
                             result: result.clone(),
                         }));
                         tool_results.push(result);
                     }
                     ProviderEvent::ToolResult { result } => {
-                        emitted_events.push(ServerEvent::ToolCompleted(ToolCompleted {
+                        emit_event(ServerEvent::ToolCompleted(ToolCompleted {
                             session_id: session.id.clone(),
                             result: result.clone(),
                         }));
@@ -138,11 +161,11 @@ impl AgentRuntime {
             }
 
             if tool_results.is_empty() {
-                emitted_events.push(ServerEvent::Final(FinalMessage {
+                emit_event(ServerEvent::Final(FinalMessage {
                     session_id: session.id.clone(),
                     message: assistant_message,
                 }));
-                return Ok(emitted_events);
+                return Ok(());
             }
 
             for tool_result in tool_results {

--- a/crates/rho-agent/src/server.rs
+++ b/crates/rho-agent/src/server.rs
@@ -1,0 +1,601 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use axum::{
+    Router,
+    extract::{
+        State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    response::IntoResponse,
+    routing::get,
+};
+use futures_util::{SinkExt, StreamExt};
+use rho_core::{
+    MessageRole,
+    protocol::{
+        ClientEnvelope, ClientEvent, ErrorEvent, PROTOCOL_VERSION, ServerEnvelope, ServerEvent,
+        SessionAck,
+    },
+    providers::{Provider, ProviderKind, anthropic::AnthropicProvider, openai::OpenAiProvider},
+};
+use thiserror::Error;
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+};
+
+use crate::{AgentRuntime, AgentSession};
+
+#[derive(Clone)]
+pub struct AgentServer {
+    state: AppState,
+}
+
+impl AgentServer {
+    pub fn new(
+        runtime: AgentRuntime,
+        provider: Arc<dyn Provider>,
+        model: impl Into<String>,
+    ) -> Self {
+        let state = AppState {
+            runtime,
+            provider,
+            model: model.into(),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            next_session_id: Arc::new(AtomicU64::new(1)),
+        };
+        Self { state }
+    }
+
+    pub async fn serve(self, bind: impl AsRef<str>) -> Result<(), AgentServerError> {
+        let bind_text = bind.as_ref().to_string();
+        let bind_addr = bind_text.parse::<SocketAddr>().map_err(|error| {
+            AgentServerError::InvalidBindAddress {
+                bind: bind_text,
+                error,
+            }
+        })?;
+        let listener = TcpListener::bind(bind_addr)
+            .await
+            .map_err(AgentServerError::Bind)?;
+        self.serve_with_listener(listener).await
+    }
+
+    pub async fn serve_with_listener(self, listener: TcpListener) -> Result<(), AgentServerError> {
+        let router = Router::new()
+            .route("/ws", get(ws_handler))
+            .with_state(self.state);
+        axum::serve(listener, router)
+            .await
+            .map_err(AgentServerError::Serve)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AgentServerError {
+    #[error("invalid bind address `{bind}`: {error}")]
+    InvalidBindAddress {
+        bind: String,
+        #[source]
+        error: std::net::AddrParseError,
+    },
+    #[error("failed to bind listener: {0}")]
+    Bind(#[source] std::io::Error),
+    #[error("websocket server failed: {0}")]
+    Serve(#[source] std::io::Error),
+    #[error("unsupported provider kind `{0}`")]
+    UnsupportedProviderKind(String),
+}
+
+pub fn build_provider(kind: ProviderKind) -> Result<Arc<dyn Provider>, AgentServerError> {
+    match kind {
+        ProviderKind::OpenAi => Ok(Arc::new(OpenAiProvider::new())),
+        ProviderKind::Anthropic => Ok(Arc::new(AnthropicProvider::new())),
+        _ => Err(AgentServerError::UnsupportedProviderKind(format!(
+            "{kind:?}"
+        ))),
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    runtime: AgentRuntime,
+    provider: Arc<dyn Provider>,
+    model: String,
+    sessions: Arc<Mutex<HashMap<String, SessionState>>>,
+    next_session_id: Arc<AtomicU64>,
+}
+
+struct SessionState {
+    session: Arc<Mutex<AgentSession>>,
+    in_flight: Option<JoinHandle<()>>,
+}
+
+impl SessionState {
+    fn new(session: AgentSession) -> Self {
+        Self {
+            session: Arc::new(Mutex::new(session)),
+            in_flight: None,
+        }
+    }
+}
+
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(|socket| handle_websocket(socket, state))
+}
+
+async fn handle_websocket(stream: WebSocket, state: AppState) {
+    let (mut sink, mut source) = stream.split();
+    let (outbound_sender, mut outbound_receiver) = mpsc::unbounded_channel::<ServerEnvelope>();
+
+    let writer_task = tokio::spawn(async move {
+        while let Some(envelope) = outbound_receiver.recv().await {
+            let payload = match serde_json::to_string(&envelope) {
+                Ok(payload) => payload,
+                Err(_) => break,
+            };
+
+            if sink.send(Message::Text(payload.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    while let Some(next_message) = source.next().await {
+        match next_message {
+            Ok(Message::Text(text)) => {
+                handle_text_message(&state, &outbound_sender, text.as_str()).await;
+            }
+            Ok(Message::Binary(_)) => send_error(
+                &outbound_sender,
+                None,
+                "invalid_message",
+                "binary websocket frames are not supported",
+            ),
+            Ok(Message::Ping(_) | Message::Pong(_)) => {}
+            Ok(Message::Close(_)) => break,
+            Err(error) => {
+                send_error(
+                    &outbound_sender,
+                    None,
+                    "websocket_receive_error",
+                    format!("failed to receive websocket frame: {error}"),
+                );
+                break;
+            }
+        }
+    }
+
+    writer_task.abort();
+}
+
+async fn handle_text_message(
+    state: &AppState,
+    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    text: &str,
+) {
+    let envelope: ClientEnvelope = match serde_json::from_str(text) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            send_error(
+                outbound_sender,
+                None,
+                "invalid_json",
+                format!("invalid client envelope JSON: {error}"),
+            );
+            return;
+        }
+    };
+
+    if envelope.version != PROTOCOL_VERSION {
+        send_error(
+            outbound_sender,
+            None,
+            "invalid_protocol_version",
+            format!(
+                "unsupported protocol version {}; expected {}",
+                envelope.version, PROTOCOL_VERSION
+            ),
+        );
+        return;
+    }
+
+    handle_client_event(state, outbound_sender, envelope.event).await;
+}
+
+async fn handle_client_event(
+    state: &AppState,
+    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    event: ClientEvent,
+) {
+    match event {
+        ClientEvent::StartSession(start_session) => {
+            let mut sessions = state.sessions.lock().await;
+            let session_id = start_session
+                .session_id
+                .unwrap_or_else(|| allocate_session_id(state, &sessions));
+
+            if sessions.contains_key(&session_id) {
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "session_exists",
+                    "session already exists",
+                );
+                return;
+            }
+
+            sessions.insert(
+                session_id.clone(),
+                SessionState::new(state.runtime.start_session(session_id.clone())),
+            );
+            send_event(
+                outbound_sender,
+                ServerEvent::SessionAck(SessionAck { session_id }),
+            );
+        }
+        ClientEvent::UserMessage(user_message) => {
+            if user_message.message.role != MessageRole::User {
+                send_error(
+                    outbound_sender,
+                    Some(user_message.session_id),
+                    "invalid_message_role",
+                    "user_message payload must contain a message with role `user`",
+                );
+                return;
+            }
+
+            let session_id = user_message.session_id;
+            let user_content = user_message.message.content;
+            let mut sessions = state.sessions.lock().await;
+
+            let Some(session_state) = sessions.get_mut(&session_id) else {
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "session_not_found",
+                    "session was not found",
+                );
+                return;
+            };
+
+            if let Some(handle) = &session_state.in_flight
+                && !handle.is_finished()
+            {
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "request_in_flight",
+                    "session already has an in-flight request",
+                );
+                return;
+            }
+
+            session_state.in_flight = None;
+
+            let runtime = state.runtime.clone();
+            let model = state.model.clone();
+            let provider = Arc::clone(&state.provider);
+            let session = Arc::clone(&session_state.session);
+            let outbound_sender = outbound_sender.clone();
+            let sessions = Arc::clone(&state.sessions);
+            let cleanup_session_id = session_id.clone();
+
+            let task = tokio::spawn(async move {
+                let run_result = {
+                    let mut session_guard = session.lock().await;
+                    runtime
+                        .run_user_message_streaming(
+                            &mut session_guard,
+                            provider.as_ref(),
+                            model,
+                            user_content,
+                            |event| send_event(&outbound_sender, event),
+                        )
+                        .await
+                };
+
+                if let Err(error) = run_result {
+                    send_error(
+                        &outbound_sender,
+                        Some(cleanup_session_id.clone()),
+                        "runtime_error",
+                        error.to_string(),
+                    );
+                }
+
+                let mut sessions_guard = sessions.lock().await;
+                if let Some(session_state) = sessions_guard.get_mut(&cleanup_session_id) {
+                    session_state.in_flight = None;
+                }
+            });
+
+            session_state.in_flight = Some(task);
+        }
+        ClientEvent::Cancel(cancel_request) => {
+            let session_id = cancel_request.session_id;
+            let mut sessions = state.sessions.lock().await;
+
+            let Some(session_state) = sessions.get_mut(&session_id) else {
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "session_not_found",
+                    "session was not found",
+                );
+                return;
+            };
+
+            if let Some(task) = session_state.in_flight.take() {
+                task.abort();
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "cancelled",
+                    "in-flight request cancelled",
+                );
+            } else {
+                send_error(
+                    outbound_sender,
+                    Some(session_id),
+                    "request_not_in_flight",
+                    "session has no in-flight request to cancel",
+                );
+            }
+        }
+    }
+}
+
+fn allocate_session_id(state: &AppState, sessions: &HashMap<String, SessionState>) -> String {
+    loop {
+        let id = format!(
+            "session-{}",
+            state.next_session_id.fetch_add(1, Ordering::Relaxed)
+        );
+        if !sessions.contains_key(&id) {
+            return id;
+        }
+    }
+}
+
+fn send_event(outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>, event: ServerEvent) {
+    let _ = outbound_sender.send(ServerEnvelope::new(event));
+}
+
+fn send_error(
+    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    session_id: Option<String>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) {
+    send_event(
+        outbound_sender,
+        ServerEvent::Error(ErrorEvent {
+            session_id,
+            code: code.into(),
+            message: message.into(),
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex as StdMutex},
+        time::Duration,
+    };
+
+    use rho_core::{
+        Message,
+        providers::{ProviderError, ProviderRequest, ProviderStream},
+        stream::ProviderEvent,
+    };
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    type FakeResponse = Vec<Result<ProviderEvent, ProviderError>>;
+    type FakeResponseQueue = VecDeque<FakeResponse>;
+
+    #[tokio::test]
+    async fn start_session_emits_session_ack() {
+        let state = test_state(Arc::new(FakeProvider::new(vec![])));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::StartSession(rho_core::protocol::StartSession { session_id: None }),
+        )
+        .await;
+
+        let envelope = rx.recv().await.expect("expected outbound envelope");
+        assert!(matches!(
+            envelope.event,
+            ServerEvent::SessionAck(SessionAck { .. })
+        ));
+        assert_eq!(state.sessions.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn user_message_for_unknown_session_emits_error() {
+        let state = test_state(Arc::new(FakeProvider::new(vec![])));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::UserMessage(rho_core::protocol::UserMessage {
+                session_id: "missing".to_string(),
+                message: Message::new(MessageRole::User, "hi"),
+            }),
+        )
+        .await;
+
+        let envelope = rx.recv().await.expect("expected outbound envelope");
+        assert!(matches!(
+            envelope.event,
+            ServerEvent::Error(ErrorEvent { code, .. }) if code == "session_not_found"
+        ));
+    }
+
+    #[tokio::test]
+    async fn user_message_streams_assistant_events() {
+        let provider = Arc::new(FakeProvider::new(vec![vec![
+            Ok(ProviderEvent::AssistantDelta {
+                delta: "hello".to_string(),
+            }),
+            Ok(ProviderEvent::Message {
+                message: Message::new(MessageRole::Assistant, "hello"),
+            }),
+            Ok(ProviderEvent::Finished),
+        ]]));
+        let state = test_state(provider);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::StartSession(rho_core::protocol::StartSession {
+                session_id: Some("session-a".to_string()),
+            }),
+        )
+        .await;
+        let _ = rx.recv().await;
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::UserMessage(rho_core::protocol::UserMessage {
+                session_id: "session-a".to_string(),
+                message: Message::new(MessageRole::User, "hello"),
+            }),
+        )
+        .await;
+
+        let first = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for first response")
+            .expect("missing first response");
+        let second = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for second response")
+            .expect("missing second response");
+
+        assert!(matches!(
+            first.event,
+            ServerEvent::AssistantDelta(_)
+                | ServerEvent::ToolStarted(_)
+                | ServerEvent::ToolCompleted(_)
+        ));
+        assert!(matches!(second.event, ServerEvent::Final(_)));
+    }
+
+    #[tokio::test]
+    async fn cancel_in_flight_request_emits_cancelled_error() {
+        let state = test_state(Arc::new(PendingProvider));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::StartSession(rho_core::protocol::StartSession {
+                session_id: Some("session-b".to_string()),
+            }),
+        )
+        .await;
+        let _ = rx.recv().await;
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::UserMessage(rho_core::protocol::UserMessage {
+                session_id: "session-b".to_string(),
+                message: Message::new(MessageRole::User, "hello"),
+            }),
+        )
+        .await;
+
+        handle_client_event(
+            &state,
+            &tx,
+            ClientEvent::Cancel(rho_core::protocol::CancelRequest {
+                session_id: "session-b".to_string(),
+            }),
+        )
+        .await;
+
+        loop {
+            let envelope = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("timed out waiting for cancel response")
+                .expect("missing cancel response");
+
+            if let ServerEvent::Error(error) = envelope.event {
+                assert_eq!(error.code, "cancelled");
+                break;
+            }
+        }
+    }
+
+    fn test_state(provider: Arc<dyn Provider>) -> AppState {
+        AppState {
+            runtime: AgentRuntime::new(),
+            provider,
+            model: "test-model".to_string(),
+            sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            next_session_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakeProvider {
+        responses: Arc<StdMutex<FakeResponseQueue>>,
+    }
+
+    impl FakeProvider {
+        fn new(responses: Vec<FakeResponse>) -> Self {
+            Self {
+                responses: Arc::new(StdMutex::new(responses.into_iter().collect())),
+            }
+        }
+    }
+
+    impl Provider for FakeProvider {
+        fn kind(&self) -> ProviderKind {
+            ProviderKind::OpenAi
+        }
+
+        fn stream(&self, _request: ProviderRequest) -> ProviderStream {
+            let events = self
+                .responses
+                .lock()
+                .expect("responses mutex should be available")
+                .pop_front()
+                .unwrap_or_default();
+            Box::pin(futures_util::stream::iter(events))
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct PendingProvider;
+
+    impl Provider for PendingProvider {
+        fn kind(&self) -> ProviderKind {
+            ProviderKind::OpenAi
+        }
+
+        fn stream(&self, _request: ProviderRequest) -> ProviderStream {
+            Box::pin(futures_util::stream::pending())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `rho-agent` websocket server transport with `/ws` endpoint (`AgentServer`) and typed protocol envelope handling
- implement server-side session lifecycle for `start_session`, `user_message`, and `cancel`
- stream runtime events as protocol server events (`assistant_delta`, `tool_started`, `tool_completed`, `final`) and surface structured error events
- add provider factory wiring (`openai`/`anthropic`) for server runtime use
- extend runtime with a streaming emitter API (`run_user_message_streaming`) so websocket transport can forward events incrementally
- add `rho-agent` websocket/session unit tests for session ack, unknown session errors, streaming responses, and cancel behavior

## Validation
- `cargo +nightly fmt --all --check`
- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace`

Closes #5
