### PR TITLE
Issue #7: wire rho CLI serve/tui end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "rho-agent",
+ "rho-core",
  "rho-tui",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,60 @@
 # rho
 
-an agent harness
+Minimal Rust reimplementation of core pi-mono ideas with:
+- shared provider/protocol contracts in `rho-core`
+- agent runtime + websocket server in `rho-agent`
+- websocket TUI client in `rho-tui`
+- top-level CLI in `rho`
+
+## Quickstart
+
+Build once:
+
+```sh
+cargo build --workspace
+```
+
+Run server (Machine A):
+
+```sh
+OPENAI_API_KEY=... cargo run -p rho -- serve \
+  --bind 0.0.0.0:8787 \
+  --provider openai \
+  --model gpt-4o-mini
+```
+
+or Anthropic:
+
+```sh
+ANTHROPIC_API_KEY=... cargo run -p rho -- serve \
+  --bind 0.0.0.0:8787 \
+  --provider anthropic \
+  --model claude-3-5-haiku-latest
+```
+
+Run TUI client (Machine B):
+
+```sh
+cargo run -p rho -- tui --url ws://<machine-a-host>:8787/ws
+```
+
+Inside TUI:
+- type a prompt and press Enter to send
+- `/cancel` cancels an in-flight request
+- `/quit` exits the client
+
+## Cross-Machine Smoke Test
+
+1. On Machine A, run `rho serve` with a valid provider key.
+2. On Machine B, run `rho tui --url ws://<machine-a-host>:8787/ws`.
+3. Send a prompt and verify:
+   - assistant text streams incrementally
+   - tool lifecycle events render
+   - a final response arrives
 
 ## License
 
 This project is dual-licensed under either of:
-
 - MIT License ([`LICENSE-MIT`](LICENSE-MIT))
 - Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE))
 

--- a/bins/rho/Cargo.toml
+++ b/bins/rho/Cargo.toml
@@ -7,4 +7,6 @@ license.workspace = true
 [dependencies]
 clap.workspace = true
 rho-agent = { path = "../../crates/rho-agent" }
+rho-core = { path = "../../crates/rho-core" }
 rho-tui = { path = "../../crates/rho-tui" }
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/bins/rho/src/main.rs
+++ b/bins/rho/src/main.rs
@@ -1,5 +1,6 @@
-use clap::{Parser, Subcommand};
-use rho_agent::AgentRuntime;
+use clap::{Parser, Subcommand, ValueEnum};
+use rho_agent::{AgentRuntime, AgentServer, build_provider};
+use rho_core::providers::ProviderKind;
 use rho_tui::TuiClient;
 
 #[derive(Debug, Parser)]
@@ -14,8 +15,8 @@ enum Command {
     Serve {
         #[arg(long)]
         bind: String,
-        #[arg(long)]
-        provider: String,
+        #[arg(long, value_enum)]
+        provider: ProviderArg,
         #[arg(long)]
         model: String,
     },
@@ -25,7 +26,30 @@ enum Command {
     },
 }
 
-fn main() {
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ProviderArg {
+    Openai,
+    Anthropic,
+}
+
+impl ProviderArg {
+    fn to_provider_kind(self) -> ProviderKind {
+        match self {
+            ProviderArg::Openai => ProviderKind::OpenAi,
+            ProviderArg::Anthropic => ProviderKind::Anthropic,
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -35,14 +59,20 @@ fn main() {
             model,
         } => {
             let runtime = AgentRuntime::new();
+            let provider_kind = provider.to_provider_kind();
+            let provider_impl = build_provider(provider_kind)?;
+            let server = AgentServer::new(runtime.clone(), provider_impl, model);
             println!(
-                "serve scaffold: bind={bind} provider={provider} model={model} protocol_version={}",
+                "rho serve listening on {bind} with provider={provider_kind:?} protocol_version={}",
                 runtime.protocol_version()
             );
+            server.serve(bind).await?;
         }
         Command::Tui { url } => {
             let client = TuiClient::new(url);
-            println!("tui scaffold: url={}", client.url());
+            client.run().await?;
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- wire `bins/rho` to the implemented runtime/server/client flows
- implement `rho serve --bind --provider --model` with typed provider parsing and `rho-agent` websocket server startup
- implement `rho tui --url` to run the interactive websocket client from `rho-tui`
- update README with local/cross-machine quickstart and smoke-test instructions for remote usage

## Validation
- `cargo +nightly fmt --all --check`
- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace`

Closes #7
