### PR TITLE
Strongly type supported models

### DIFF
--- a/bins/rho/src/main.rs
+++ b/bins/rho/src/main.rs
@@ -2,14 +2,17 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use rho_agent::{AgentRuntime, AgentServer, AgentServerError, build_provider};
-use rho_core::{protocol::PROTOCOL_VERSION, providers::ProviderKind};
+use rho_core::{
+    protocol::PROTOCOL_VERSION,
+    providers::{ModelKind, ProviderKind},
+};
 use rho_tui::TuiClient;
 use tokio::net::TcpListener;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 const DEFAULT_BIND: &str = "127.0.0.1:0";
-const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+const DEFAULT_MODEL: ModelArg = ModelArg::ClaudeSonnet46;
 const DEFAULT_PROVIDER: ProviderArg = ProviderArg::Anthropic;
 
 #[derive(Debug, Parser)]
@@ -27,8 +30,8 @@ struct ServeArgs {
     bind: String,
     #[arg(long, value_enum, default_value_t = DEFAULT_PROVIDER)]
     provider: ProviderArg,
-    #[arg(long, default_value = DEFAULT_MODEL)]
-    model: String,
+    #[arg(long, value_enum, default_value_t = DEFAULT_MODEL)]
+    model: ModelArg,
 }
 
 #[derive(Debug, Subcommand)]
@@ -46,11 +49,28 @@ enum ProviderArg {
     Anthropic,
 }
 
-impl ProviderArg {
-    fn to_provider_kind(self) -> ProviderKind {
-        match self {
+impl From<ProviderArg> for ProviderKind {
+    fn from(value: ProviderArg) -> Self {
+        match value {
             ProviderArg::Openai => ProviderKind::OpenAi,
             ProviderArg::Anthropic => ProviderKind::Anthropic,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ModelArg {
+    #[value(name = "gpt-5.2-2025-12-11")]
+    Gpt52,
+    #[value(name = "claude-sonnet-4-6")]
+    ClaudeSonnet46,
+}
+
+impl From<ModelArg> for ModelKind {
+    fn from(value: ModelArg) -> Self {
+        match value {
+            ModelArg::Gpt52 => ModelKind::Gpt52,
+            ModelArg::ClaudeSonnet46 => ModelKind::ClaudeSonnet46,
         }
     }
 }
@@ -80,12 +100,19 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 fn build_server(
     provider: ProviderArg,
-    model: String,
+    model: ModelArg,
 ) -> Result<(ProviderKind, AgentServer), AgentServerError> {
     let runtime = AgentRuntime::new();
-    let provider_kind = provider.to_provider_kind();
+    let provider_kind: ProviderKind = provider.into();
+    let model_kind: ModelKind = model.into();
+    if model_kind.provider_kind() != provider_kind {
+        return Err(AgentServerError::UnsupportedModelForProvider {
+            provider: provider_kind,
+            model: model_kind,
+        });
+    }
     let provider_impl = build_provider(provider_kind)?;
-    let server = AgentServer::new(runtime, provider_impl, model);
+    let server = AgentServer::new(runtime, provider_impl, model_kind);
     Ok((provider_kind, server))
 }
 
@@ -185,7 +212,7 @@ mod tests {
             "--provider",
             "openai",
             "--model",
-            "gpt-4o-mini",
+            "gpt-5.2-2025-12-11",
         ]);
 
         let Some(Command::Serve(serve)) = cli.command else {
@@ -193,7 +220,22 @@ mod tests {
         };
         assert_eq!(serve.bind, "0.0.0.0:8787");
         assert_eq!(serve.provider, ProviderArg::Openai);
-        assert_eq!(serve.model, "gpt-4o-mini");
+        assert_eq!(serve.model, ModelArg::Gpt52);
+    }
+
+    #[test]
+    fn build_server_rejects_provider_model_mismatch() {
+        let error = match build_server(ProviderArg::Openai, ModelArg::ClaudeSonnet46) {
+            Ok(_) => panic!("mismatched provider/model should fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            AgentServerError::UnsupportedModelForProvider {
+                provider: ProviderKind::OpenAi,
+                model: ModelKind::ClaudeSonnet46,
+            }
+        ));
     }
 
     #[test]

--- a/crates/rho-agent/src/runtime.rs
+++ b/crates/rho-agent/src/runtime.rs
@@ -11,7 +11,7 @@ use rho_core::{
     protocol::{
         AssistantDelta, FinalMessage, PROTOCOL_VERSION, ServerEvent, ToolCompleted, ToolStarted,
     },
-    providers::{Provider, ProviderError, ProviderRequest},
+    providers::{ModelKind, Provider, ProviderError, ProviderRequest},
     stream::ProviderEvent,
     tool::{ToolCall, ToolDefinition, ToolResult},
 };
@@ -66,10 +66,9 @@ impl AgentRuntime {
         &self,
         session: &mut AgentSession,
         provider: &dyn Provider,
-        model: impl Into<String>,
+        model: ModelKind,
         user_content: impl Into<String>,
     ) -> Result<Vec<ServerEvent>, AgentError> {
-        let model = model.into();
         let user_content = user_content.into();
         let mut emitted_events = Vec::new();
         self.run_user_message_streaming(session, provider, model, user_content, |event| {
@@ -83,19 +82,18 @@ impl AgentRuntime {
         &self,
         session: &mut AgentSession,
         provider: &dyn Provider,
-        model: impl Into<String>,
+        model: ModelKind,
         user_content: impl Into<String>,
         mut emit_event: F,
     ) -> Result<(), AgentError>
     where
         F: FnMut(ServerEvent),
     {
-        let model = model.into();
         let user_content = user_content.into();
         session
             .messages
             .push(Message::new(MessageRole::User, user_content));
-        self.run_completion_loop(session, provider, &model, &mut emit_event)
+        self.run_completion_loop(session, provider, model, &mut emit_event)
             .await
     }
 
@@ -103,7 +101,7 @@ impl AgentRuntime {
         &self,
         session: &mut AgentSession,
         provider: &dyn Provider,
-        model: &str,
+        model: ModelKind,
         emit_event: &mut F,
     ) -> Result<(), AgentError>
     where
@@ -113,7 +111,7 @@ impl AgentRuntime {
         let builtin_tools = builtin_tool_definitions();
 
         for iteration in 0..=self.max_tool_iterations {
-            let request = ProviderRequest::new(model.to_string(), session.messages.clone())
+            let request = ProviderRequest::new(model, session.messages.clone())
                 .with_tools(builtin_tools.clone());
             let mut stream = provider.stream(request);
 
@@ -459,7 +457,7 @@ mod tests {
 
     use rho_core::{
         message::decode_assistant_message_content,
-        providers::{ProviderKind, ProviderRequest, ProviderStream},
+        providers::{ModelKind, ProviderKind, ProviderRequest, ProviderStream},
         tool::ToolCall,
     };
     use serde_json::{Value, json};
@@ -485,7 +483,7 @@ mod tests {
             ]]);
 
             let events = runtime
-                .run_user_message(&mut session, &provider, "test-model", "hi")
+                .run_user_message(&mut session, &provider, ModelKind::Gpt52, "hi")
                 .await
                 .expect("run should succeed");
 
@@ -554,7 +552,7 @@ mod tests {
             ]);
 
             let events = runtime
-                .run_user_message(&mut session, &provider, "test-model", "read the file")
+                .run_user_message(&mut session, &provider, ModelKind::Gpt52, "read the file")
                 .await
                 .expect("run should succeed");
 
@@ -636,7 +634,7 @@ mod tests {
             ]);
 
             let events = runtime
-                .run_user_message(&mut session, &provider, "test-model", "do something")
+                .run_user_message(&mut session, &provider, ModelKind::Gpt52, "do something")
                 .await
                 .expect("run should continue after tool failure");
 
@@ -686,7 +684,7 @@ mod tests {
             ]);
 
             let error = runtime
-                .run_user_message(&mut session, &provider, "test-model", "loop")
+                .run_user_message(&mut session, &provider, ModelKind::Gpt52, "loop")
                 .await
                 .expect_err("run should fail once the limit is exceeded");
             assert!(matches!(error, AgentError::MaxToolIterationsExceeded(1)));

--- a/crates/rho-agent/src/server.rs
+++ b/crates/rho-agent/src/server.rs
@@ -16,7 +16,9 @@ use rho_core::{
         ClientEnvelope, ClientEvent, ErrorEvent, PROTOCOL_VERSION, ServerEnvelope, ServerEvent,
         SessionAck,
     },
-    providers::{Provider, ProviderKind, anthropic::AnthropicProvider, openai::OpenAiProvider},
+    providers::{
+        ModelKind, Provider, ProviderKind, anthropic::AnthropicProvider, openai::OpenAiProvider,
+    },
 };
 use thiserror::Error;
 use tokio::{
@@ -34,15 +36,11 @@ pub struct AgentServer {
 }
 
 impl AgentServer {
-    pub fn new(
-        runtime: AgentRuntime,
-        provider: Arc<dyn Provider>,
-        model: impl Into<String>,
-    ) -> Self {
+    pub fn new(runtime: AgentRuntime, provider: Arc<dyn Provider>, model: ModelKind) -> Self {
         let state = AppState {
             runtime,
             provider,
-            model: model.into(),
+            model,
             sessions: Arc::new(Mutex::new(HashMap::new())),
         };
         Self { state }
@@ -86,6 +84,11 @@ pub enum AgentServerError {
     Serve(#[source] std::io::Error),
     #[error("unsupported provider kind `{0}`")]
     UnsupportedProviderKind(String),
+    #[error("model `{model}` is not supported for provider `{provider:?}`")]
+    UnsupportedModelForProvider {
+        provider: ProviderKind,
+        model: ModelKind,
+    },
 }
 
 pub fn build_provider(kind: ProviderKind) -> Result<Arc<dyn Provider>, AgentServerError> {
@@ -102,7 +105,7 @@ pub fn build_provider(kind: ProviderKind) -> Result<Arc<dyn Provider>, AgentServ
 struct AppState {
     runtime: AgentRuntime,
     provider: Arc<dyn Provider>,
-    model: String,
+    model: ModelKind,
     sessions: Arc<Mutex<HashMap<String, SessionState>>>,
 }
 
@@ -289,7 +292,7 @@ async fn handle_client_event(
             session_state.in_flight = None;
 
             let runtime = state.runtime.clone();
-            let model = state.model.clone();
+            let model = state.model;
             let provider = Arc::clone(&state.provider);
             let session = Arc::clone(&session_state.session);
             let outbound_sender = outbound_sender.clone();
@@ -427,7 +430,7 @@ mod tests {
 
     use rho_core::{
         Message,
-        providers::{ProviderError, ProviderRequest, ProviderStream},
+        providers::{ModelKind, ProviderError, ProviderRequest, ProviderStream},
         stream::ProviderEvent,
     };
     use tokio::sync::mpsc;
@@ -607,7 +610,7 @@ mod tests {
         AppState {
             runtime: AgentRuntime::new(),
             provider,
-            model: "test-model".to_string(),
+            model: ModelKind::Gpt52,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }

--- a/crates/rho-core/src/providers/mod.rs
+++ b/crates/rho-core/src/providers/mod.rs
@@ -34,17 +34,46 @@ pub enum ProviderKind {
     Anthropic,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ModelKind {
+    Gpt52,
+    ClaudeSonnet46,
+}
+
+impl ModelKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Gpt52 => "gpt-5.2-2025-12-11",
+            Self::ClaudeSonnet46 => "claude-sonnet-4-6",
+        }
+    }
+
+    pub fn provider_kind(self) -> ProviderKind {
+        match self {
+            Self::Gpt52 => ProviderKind::OpenAi,
+            Self::ClaudeSonnet46 => ProviderKind::Anthropic,
+        }
+    }
+}
+
+impl std::fmt::Display for ModelKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderRequest {
-    pub model: String,
+    pub model: ModelKind,
     pub messages: Vec<Message>,
     pub tools: Vec<ToolDefinition>,
 }
 
 impl ProviderRequest {
-    pub fn new(model: impl Into<String>, messages: Vec<Message>) -> Self {
+    pub fn new(model: ModelKind, messages: Vec<Message>) -> Self {
         Self {
-            model: model.into(),
+            model,
             messages,
             tools: Vec::new(),
         }
@@ -120,7 +149,7 @@ pub(crate) fn to_rig_chat_request(
     };
 
     Ok(RigChatRequest {
-        model: request.model,
+        model: request.model.to_string(),
         prompt,
         history: chat_messages,
         preamble,
@@ -311,7 +340,7 @@ mod tests {
     #[test]
     fn to_rig_chat_request_extracts_preamble_prompt_history_and_tools() {
         let request = ProviderRequest::new(
-            "test-model",
+            ModelKind::Gpt52,
             vec![
                 Message::new(MessageRole::System, "system-a"),
                 Message::new(MessageRole::System, "system-b"),
@@ -341,7 +370,7 @@ mod tests {
 
         let rig_request = to_rig_chat_request(request).expect("request conversion should succeed");
 
-        assert_eq!(rig_request.model, "test-model");
+        assert_eq!(rig_request.model, ModelKind::Gpt52.as_str());
         assert_eq!(
             rig_request.preamble,
             Some("system-a\n\nsystem-b".to_string())
@@ -360,7 +389,7 @@ mod tests {
     #[test]
     fn to_rig_chat_request_requires_a_non_system_prompt() {
         let request = ProviderRequest::new(
-            "test-model",
+            ModelKind::Gpt52,
             vec![Message::new(MessageRole::System, "only system")],
         );
 
@@ -371,7 +400,7 @@ mod tests {
     #[test]
     fn to_rig_chat_request_preserves_tool_result_call_id() {
         let request = ProviderRequest::new(
-            "test-model",
+            ModelKind::Gpt52,
             vec![
                 Message::new(MessageRole::User, "first"),
                 Message::new(
@@ -403,7 +432,7 @@ mod tests {
     #[test]
     fn to_rig_chat_request_preserves_assistant_tool_calls() {
         let request = ProviderRequest::new(
-            "test-model",
+            ModelKind::Gpt52,
             vec![
                 Message::new(MessageRole::User, "first"),
                 Message::new(
@@ -449,7 +478,7 @@ mod tests {
     #[test]
     fn to_rig_chat_request_preserves_distinct_tool_call_id_and_call_id() {
         let request = ProviderRequest::new(
-            "test-model",
+            ModelKind::Gpt52,
             vec![
                 Message::new(MessageRole::User, "first"),
                 Message::new(


### PR DESCRIPTION
## Summary
- add ModelKind in rho-core and thread it through provider requests, runtime, and server state
- strongly type CLI --model values and enforce provider/model compatibility before startup
- remove gpt-4o-mini support and use simplified enum variants (Gpt52, ClaudeSonnet46)
- refactor CLI conversions to From impls and remove dead conversion helper

## Validation
- cargo +nightly fmt --all --check
- cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace
- cargo test --workspace