### PR TITLE
[Codex] Bound websocket channel buffers to enforce backpressure

### DIFF
--- a/crates/rho-agent/src/server.rs
+++ b/crates/rho-agent/src/server.rs
@@ -1,4 +1,12 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use axum::{
     Router,
@@ -23,12 +31,16 @@ use rho_core::{
 use thiserror::Error;
 use tokio::{
     net::TcpListener,
-    sync::{Mutex, mpsc},
+    sync::{Mutex, mpsc, watch},
     task::JoinHandle,
 };
 use uuid::Uuid;
 
 use crate::{AgentRuntime, AgentSession};
+
+const WS_OUTBOUND_BUFFER_CAPACITY: usize = 256;
+const WS_OUTBOUND_RESERVED_ERROR_SLOTS: usize = 1;
+const BACKPRESSURE_OVERFLOW_CODE: &str = "backpressure_overflow";
 
 #[derive(Clone)]
 pub struct AgentServer {
@@ -123,15 +135,69 @@ impl SessionState {
     }
 }
 
+#[derive(Clone)]
+struct OutboundChannel {
+    sender: mpsc::Sender<ServerEnvelope>,
+    overflow_tx: watch::Sender<bool>,
+    overflow_reported: Arc<AtomicBool>,
+}
+
+impl OutboundChannel {
+    fn new(sender: mpsc::Sender<ServerEnvelope>, overflow_tx: watch::Sender<bool>) -> Self {
+        Self {
+            sender,
+            overflow_tx,
+            overflow_reported: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn send(&self, envelope: ServerEnvelope) {
+        if self.overflow_reported.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let is_error_event = matches!(envelope.event, ServerEvent::Error(_));
+        if !is_error_event && self.sender.capacity() <= WS_OUTBOUND_RESERVED_ERROR_SLOTS {
+            self.report_overflow();
+            return;
+        }
+
+        match self.sender.try_send(envelope) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => self.report_overflow(),
+            Err(mpsc::error::TrySendError::Closed(_)) => {}
+        }
+    }
+
+    fn report_overflow(&self) {
+        if self.overflow_reported.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let overflow_event = ServerEnvelope::new(ServerEvent::Error(ErrorEvent {
+            session_id: None,
+            code: BACKPRESSURE_OVERFLOW_CODE.to_string(),
+            message: format!(
+                "outbound websocket buffer exceeded safe capacity (buffer_size={WS_OUTBOUND_BUFFER_CAPACITY})"
+            ),
+        }));
+        let _ = self.sender.try_send(overflow_event);
+        let _ = self.overflow_tx.send(true);
+    }
+}
+
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     ws.on_upgrade(|socket| handle_websocket(socket, state))
 }
 
 async fn handle_websocket(stream: WebSocket, state: AppState) {
     let (mut sink, mut source) = stream.split();
-    let (outbound_sender, mut outbound_receiver) = mpsc::unbounded_channel::<ServerEnvelope>();
+    let (outbound_sender, mut outbound_receiver) =
+        mpsc::channel::<ServerEnvelope>(WS_OUTBOUND_BUFFER_CAPACITY);
+    let (overflow_tx, mut overflow_rx) = watch::channel(false);
+    let outbound = OutboundChannel::new(outbound_sender, overflow_tx);
 
-    let writer_task = tokio::spawn(async move {
+    let mut writer_task = tokio::spawn(async move {
         while let Some(envelope) = outbound_receiver.recv().await {
             let payload = match serde_json::to_string(&envelope) {
                 Ok(payload) => payload,
@@ -144,39 +210,61 @@ async fn handle_websocket(stream: WebSocket, state: AppState) {
         }
     });
 
-    while let Some(next_message) = source.next().await {
-        match next_message {
-            Ok(Message::Text(text)) => {
-                handle_text_message(&state, &outbound_sender, text.as_str()).await;
+    let mut overflow_disconnect = false;
+    loop {
+        tokio::select! {
+            changed = overflow_rx.changed() => {
+                if changed.is_ok() && *overflow_rx.borrow() {
+                    overflow_disconnect = true;
+                    break;
+                }
+                if changed.is_err() {
+                    break;
+                }
             }
-            Ok(Message::Binary(_)) => send_error(
-                &outbound_sender,
-                None,
-                "invalid_message",
-                "binary websocket frames are not supported",
-            ),
-            Ok(Message::Ping(_) | Message::Pong(_)) => {}
-            Ok(Message::Close(_)) => break,
-            Err(error) => {
-                send_error(
-                    &outbound_sender,
-                    None,
-                    "websocket_receive_error",
-                    format!("failed to receive websocket frame: {error}"),
-                );
-                break;
+            next_message = source.next() => {
+                let Some(next_message) = next_message else {
+                    break;
+                };
+                match next_message {
+                    Ok(Message::Text(text)) => {
+                        handle_text_message(&state, &outbound, text.as_str()).await;
+                    }
+                    Ok(Message::Binary(_)) => send_error(
+                        &outbound,
+                        None,
+                        "invalid_message",
+                        "binary websocket frames are not supported",
+                    ),
+                    Ok(Message::Ping(_) | Message::Pong(_)) => {}
+                    Ok(Message::Close(_)) => break,
+                    Err(error) => {
+                        send_error(
+                            &outbound,
+                            None,
+                            "websocket_receive_error",
+                            format!("failed to receive websocket frame: {error}"),
+                        );
+                        break;
+                    }
+                }
             }
         }
     }
 
-    writer_task.abort();
+    if overflow_disconnect {
+        if tokio::time::timeout(Duration::from_millis(250), &mut writer_task)
+            .await
+            .is_err()
+        {
+            writer_task.abort();
+        }
+    } else {
+        writer_task.abort();
+    }
 }
 
-async fn handle_text_message(
-    state: &AppState,
-    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
-    text: &str,
-) {
+async fn handle_text_message(state: &AppState, outbound_sender: &OutboundChannel, text: &str) {
     let envelope: ClientEnvelope = match serde_json::from_str(text) {
         Ok(envelope) => envelope,
         Err(error) => {
@@ -208,7 +296,7 @@ async fn handle_text_message(
 
 async fn handle_client_event(
     state: &AppState,
-    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    outbound_sender: &OutboundChannel,
     event: ClientEvent,
 ) {
     match event {
@@ -371,7 +459,7 @@ async fn handle_client_event(
 
 fn get_session_state_mut<'a>(
     sessions: &'a mut HashMap<String, SessionState>,
-    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    outbound_sender: &OutboundChannel,
     session_id: &str,
 ) -> Option<&'a mut SessionState> {
     if let Some(session_state) = sessions.get_mut(session_id) {
@@ -400,12 +488,12 @@ fn is_valid_session_id(session_id: &str) -> bool {
     Uuid::try_parse(session_id).is_ok()
 }
 
-fn send_event(outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>, event: ServerEvent) {
-    let _ = outbound_sender.send(ServerEnvelope::new(event));
+fn send_event(outbound_sender: &OutboundChannel, event: ServerEvent) {
+    outbound_sender.send(ServerEnvelope::new(event));
 }
 
 fn send_error(
-    outbound_sender: &mpsc::UnboundedSender<ServerEnvelope>,
+    outbound_sender: &OutboundChannel,
     session_id: Option<String>,
     code: impl Into<String>,
     message: impl Into<String>,
@@ -433,7 +521,7 @@ mod tests {
         providers::{ModelKind, ProviderError, ProviderRequest, ProviderStream},
         stream::ProviderEvent,
     };
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, watch};
     use uuid::Uuid;
 
     use super::*;
@@ -444,7 +532,7 @@ mod tests {
     #[tokio::test]
     async fn start_session_emits_session_ack() {
         let state = test_state(Arc::new(FakeProvider::new(vec![])));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = test_outbound_channel();
 
         handle_client_event(
             &state,
@@ -465,7 +553,7 @@ mod tests {
     #[tokio::test]
     async fn start_session_with_invalid_id_emits_error() {
         let state = test_state(Arc::new(FakeProvider::new(vec![])));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = test_outbound_channel();
 
         handle_client_event(
             &state,
@@ -487,7 +575,7 @@ mod tests {
     #[tokio::test]
     async fn user_message_for_unknown_session_emits_error() {
         let state = test_state(Arc::new(FakeProvider::new(vec![])));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = test_outbound_channel();
         let missing_session_id = "00000000-0000-4000-8000-0000000000ff".to_string();
 
         handle_client_event(
@@ -519,7 +607,7 @@ mod tests {
             Ok(ProviderEvent::Finished),
         ]]));
         let state = test_state(provider);
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = test_outbound_channel();
         let session_id = "00000000-0000-4000-8000-00000000000a".to_string();
 
         handle_client_event(
@@ -563,7 +651,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_in_flight_request_emits_cancelled_error() {
         let state = test_state(Arc::new(PendingProvider));
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = test_outbound_channel();
         let session_id = "00000000-0000-4000-8000-00000000000b".to_string();
 
         handle_client_event(
@@ -606,6 +694,42 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn outbound_channel_overflow_emits_terminal_error() {
+        let (sender, mut receiver) = mpsc::channel(2);
+        let (overflow_tx, mut overflow_rx) = watch::channel(false);
+        let outbound = OutboundChannel::new(sender, overflow_tx);
+
+        send_event(
+            &outbound,
+            ServerEvent::SessionAck(SessionAck {
+                session_id: "session-1".to_string(),
+            }),
+        );
+        send_event(
+            &outbound,
+            ServerEvent::SessionAck(SessionAck {
+                session_id: "session-2".to_string(),
+            }),
+        );
+
+        overflow_rx
+            .changed()
+            .await
+            .expect("overflow signal should be delivered");
+        assert!(*overflow_rx.borrow());
+
+        let first = receiver.recv().await.expect("expected first envelope");
+        let second = receiver.recv().await.expect("expected overflow envelope");
+
+        assert!(matches!(first.event, ServerEvent::SessionAck(_)));
+        assert!(matches!(
+            second.event,
+            ServerEvent::Error(ErrorEvent { code, .. }) if code == BACKPRESSURE_OVERFLOW_CODE
+        ));
+        assert!(receiver.try_recv().is_err());
+    }
+
     fn test_state(provider: Arc<dyn Provider>) -> AppState {
         AppState {
             runtime: AgentRuntime::new(),
@@ -613,6 +737,12 @@ mod tests {
             model: ModelKind::Gpt52,
             sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    fn test_outbound_channel() -> (OutboundChannel, mpsc::Receiver<ServerEnvelope>) {
+        let (sender, receiver) = mpsc::channel(WS_OUTBOUND_BUFFER_CAPACITY);
+        let (overflow_tx, _overflow_rx) = watch::channel(false);
+        (OutboundChannel::new(sender, overflow_tx), receiver)
     }
 
     #[derive(Debug, Clone)]

--- a/crates/rho-tui/src/client.rs
+++ b/crates/rho-tui/src/client.rs
@@ -39,6 +39,9 @@ use tokio_tungstenite::{
     tungstenite::{Error as WsError, Message as WsMessage},
 };
 
+const OUTBOUND_CHANNEL_CAPACITY: usize = 128;
+const INBOUND_CHANNEL_CAPACITY: usize = 256;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuiClient {
     url: String,
@@ -59,8 +62,8 @@ impl TuiClient {
             .map_err(TuiClientError::Connect)?;
         let (writer, reader) = socket.split();
 
-        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
-        let (inbound_tx, mut inbound_rx) = mpsc::unbounded_channel();
+        let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
+        let (inbound_tx, mut inbound_rx) = mpsc::channel(INBOUND_CHANNEL_CAPACITY);
 
         tokio::spawn(run_writer(writer, outbound_rx));
         tokio::spawn(run_reader(reader, inbound_tx));
@@ -140,6 +143,8 @@ pub enum TuiClientError {
     SessionInitialization(String),
     #[error("outbound channel is closed")]
     OutboundChannelClosed,
+    #[error("outbound channel is full")]
+    OutboundBackpressure,
 }
 
 type WsWriter = futures_util::stream::SplitSink<
@@ -639,7 +644,7 @@ impl AppState {
 
 async fn run_writer(
     mut writer: WsWriter,
-    mut outbound_rx: mpsc::UnboundedReceiver<ClientEvent>,
+    mut outbound_rx: mpsc::Receiver<ClientEvent>,
 ) -> Result<(), TuiClientError> {
     while let Some(event) = outbound_rx.recv().await {
         send_client_event(&mut writer, event).await?;
@@ -649,32 +654,39 @@ async fn run_writer(
 
 async fn run_reader(
     mut reader: WsReader,
-    inbound_tx: mpsc::UnboundedSender<NetworkEvent>,
+    inbound_tx: mpsc::Sender<NetworkEvent>,
 ) -> Result<(), TuiClientError> {
     loop {
         match recv_server_envelope(&mut reader).await {
             Ok(envelope) => {
                 if inbound_tx
                     .send(NetworkEvent::Server(envelope.event))
+                    .await
                     .is_err()
                 {
                     return Ok(());
                 }
             }
             Err(TuiClientError::Closed) => {
-                let _ = inbound_tx.send(NetworkEvent::Closed);
+                let _ = inbound_tx.send(NetworkEvent::Closed).await;
                 return Ok(());
             }
             Err(TuiClientError::Receive(err)) => {
-                let _ = inbound_tx.send(NetworkEvent::ReceiveError(err.to_string()));
+                let _ = inbound_tx
+                    .send(NetworkEvent::ReceiveError(err.to_string()))
+                    .await;
                 return Ok(());
             }
             Err(TuiClientError::Protocol(err)) => {
-                let _ = inbound_tx.send(NetworkEvent::ProtocolError(err.to_string()));
+                let _ = inbound_tx
+                    .send(NetworkEvent::ProtocolError(err.to_string()))
+                    .await;
                 return Ok(());
             }
             Err(other) => {
-                let _ = inbound_tx.send(NetworkEvent::ReceiveError(other.to_string()));
+                let _ = inbound_tx
+                    .send(NetworkEvent::ReceiveError(other.to_string()))
+                    .await;
                 return Ok(());
             }
         }
@@ -682,12 +694,14 @@ async fn run_reader(
 }
 
 fn send_outbound(
-    outbound_tx: &mpsc::UnboundedSender<ClientEvent>,
+    outbound_tx: &mpsc::Sender<ClientEvent>,
     event: ClientEvent,
 ) -> Result<(), TuiClientError> {
-    outbound_tx
-        .send(event)
-        .map_err(|_| TuiClientError::OutboundChannelClosed)
+    match outbound_tx.try_send(event) {
+        Ok(()) => Ok(()),
+        Err(mpsc::error::TrySendError::Closed(_)) => Err(TuiClientError::OutboundChannelClosed),
+        Err(mpsc::error::TrySendError::Full(_)) => Err(TuiClientError::OutboundBackpressure),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -891,7 +905,7 @@ fn draw_ui(frame: &mut Frame<'_>, app: &mut AppState) {
 fn handle_terminal_event(
     event: Event,
     app: &mut AppState,
-    outbound_tx: &mpsc::UnboundedSender<ClientEvent>,
+    outbound_tx: &mpsc::Sender<ClientEvent>,
 ) -> Result<(), TuiClientError> {
     match event {
         Event::Key(key) => handle_key_event(key, app, outbound_tx),
@@ -919,7 +933,7 @@ fn handle_mouse_event(mouse: MouseEvent, app: &mut AppState) -> Result<(), TuiCl
 fn handle_key_event(
     key: KeyEvent,
     app: &mut AppState,
-    outbound_tx: &mpsc::UnboundedSender<ClientEvent>,
+    outbound_tx: &mpsc::Sender<ClientEvent>,
 ) -> Result<(), TuiClientError> {
     if is_key_release(&key) {
         return Ok(());
@@ -1112,7 +1126,7 @@ fn handle_key_event(
 
 fn submit_input(
     app: &mut AppState,
-    outbound_tx: &mpsc::UnboundedSender<ClientEvent>,
+    outbound_tx: &mpsc::Sender<ClientEvent>,
 ) -> Result<(), TuiClientError> {
     app.scroll_to_bottom();
     let submission = app.editor.submit();
@@ -1173,7 +1187,7 @@ async fn send_client_event(
 }
 
 async fn wait_for_session_ack(
-    inbound_rx: &mut mpsc::UnboundedReceiver<NetworkEvent>,
+    inbound_rx: &mut mpsc::Receiver<NetworkEvent>,
 ) -> Result<String, TuiClientError> {
     while let Some(network_event) = inbound_rx.recv().await {
         match network_event {
@@ -1244,7 +1258,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use rho_core::{
-        protocol::{AssistantDelta, ServerEvent},
+        protocol::{AssistantDelta, ClientEvent, ServerEvent, StartSession},
         tool::{ToolCall, ToolResult},
     };
     use serde_json::json;
@@ -1351,12 +1365,30 @@ mod tests {
             "session-1".to_string(),
         );
         app.editor.insert_text("hello");
-        let (outbound_tx, _outbound_rx) = mpsc::unbounded_channel();
+        let (outbound_tx, _outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
 
         submit_input(&mut app, &outbound_tx).expect("submit should succeed");
 
         assert!(app.awaiting_assistant);
         assert!(app.active_assistant_line.is_none());
+    }
+
+    #[test]
+    fn send_outbound_returns_backpressure_when_full() {
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+
+        send_outbound(
+            &outbound_tx,
+            ClientEvent::StartSession(StartSession { session_id: None }),
+        )
+        .expect("first send should fit in channel");
+
+        let error = send_outbound(
+            &outbound_tx,
+            ClientEvent::StartSession(StartSession { session_id: None }),
+        )
+        .expect_err("second send should hit backpressure");
+        assert!(matches!(error, TuiClientError::OutboundBackpressure));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #28

### What Changed
- Automated implementation generated in a dedicated Codex worktree.

### How To Verify
- Review the PR diff and run project tests/linters.