### PR TITLE
Simplify and deduplicate code across crates

### DIFF
--- a/crates/rho-agent/src/runtime.rs
+++ b/crates/rho-agent/src/runtime.rs
@@ -185,7 +185,9 @@ impl AgentRuntime {
             }
 
             if iteration == self.max_tool_iterations {
-                return Err(max_tool_iterations_error(self.max_tool_iterations));
+                return Err(AgentError::MaxToolIterationsExceeded(
+                    self.max_tool_iterations,
+                ));
             }
         }
 
@@ -213,10 +215,6 @@ pub enum AgentError {
     MaxToolIterationsExceeded(usize),
     #[error("request cancelled")]
     Cancelled,
-}
-
-fn max_tool_iterations_error(max_tool_iterations: usize) -> AgentError {
-    AgentError::MaxToolIterationsExceeded(max_tool_iterations)
 }
 
 fn push_tool_result_event<F>(

--- a/crates/rho-tui/src/editor.rs
+++ b/crates/rho-tui/src/editor.rs
@@ -98,9 +98,7 @@ impl EditorState {
         let byte_index = char_to_byte_index(line.as_str(), self.cursor_col);
         line.insert(byte_index, ch);
         self.cursor_col += 1;
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn insert_newline(&mut self) {
@@ -112,18 +110,14 @@ impl EditorState {
         self.lines.insert(self.cursor_line + 1, tail);
         self.cursor_line += 1;
         self.cursor_col = 0;
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn insert_text(&mut self, text: &str) {
         self.push_undo_snapshot();
         self.exit_history_mode();
         self.insert_text_internal(text);
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn handle_paste(&mut self, pasted_text: String) {
@@ -153,9 +147,7 @@ impl EditorState {
             self.cursor_line -= 1;
             self.cursor_col = char_len(self.lines[self.cursor_line].as_str());
         }
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn move_right(&mut self) {
@@ -166,9 +158,7 @@ impl EditorState {
             self.cursor_line += 1;
             self.cursor_col = 0;
         }
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn move_up(&mut self) {
@@ -179,9 +169,8 @@ impl EditorState {
         let target_col = self.preferred_visual_col.unwrap_or(self.cursor_col);
         self.cursor_line -= 1;
         self.cursor_col = min(target_col, char_len(self.lines[self.cursor_line].as_str()));
+        self.reset_action_state();
         self.preferred_visual_col = Some(target_col);
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
     }
 
     pub fn move_down(&mut self) {
@@ -192,23 +181,18 @@ impl EditorState {
         let target_col = self.preferred_visual_col.unwrap_or(self.cursor_col);
         self.cursor_line += 1;
         self.cursor_col = min(target_col, char_len(self.lines[self.cursor_line].as_str()));
+        self.reset_action_state();
         self.preferred_visual_col = Some(target_col);
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
     }
 
     pub fn move_home(&mut self) {
         self.cursor_col = 0;
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn move_end(&mut self) {
         self.cursor_col = char_len(self.lines[self.cursor_line].as_str());
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn backspace(&mut self) {
@@ -218,23 +202,8 @@ impl EditorState {
 
         self.push_undo_snapshot();
         self.exit_history_mode();
-
-        if self.cursor_col > 0 {
-            let line = &mut self.lines[self.cursor_line];
-            let start = char_to_byte_index(line.as_str(), self.cursor_col - 1);
-            let end = char_to_byte_index(line.as_str(), self.cursor_col);
-            line.replace_range(start..end, "");
-            self.cursor_col -= 1;
-        } else {
-            let tail = self.lines.remove(self.cursor_line);
-            self.cursor_line -= 1;
-            self.cursor_col = char_len(self.lines[self.cursor_line].as_str());
-            self.lines[self.cursor_line].push_str(tail.as_str());
-        }
-
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.backspace_without_undo();
+        self.reset_action_state();
     }
 
     pub fn delete(&mut self) {
@@ -256,9 +225,7 @@ impl EditorState {
             self.lines[self.cursor_line].push_str(tail.as_str());
         }
 
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn delete_word_backward(&mut self) {
@@ -346,9 +313,7 @@ impl EditorState {
             self.cursor_line = snapshot.cursor_line;
             self.cursor_col = snapshot.cursor_col;
             self.history_index = None;
-            self.preferred_visual_col = None;
-            self.last_action = LastAction::Other;
-            self.last_yank_len = None;
+            self.reset_action_state();
         }
     }
 
@@ -455,9 +420,7 @@ impl EditorState {
         let end_byte = char_to_byte_index(line.as_str(), self.cursor_col);
         line.replace_range(start_byte..end_byte, replacement);
         self.cursor_col = start_col + replacement.chars().count();
-        self.preferred_visual_col = None;
-        self.last_action = LastAction::Other;
-        self.last_yank_len = None;
+        self.reset_action_state();
     }
 
     pub fn render(&self, width: usize, height: usize) -> EditorRender {
@@ -548,6 +511,12 @@ impl EditorState {
 
     fn exit_history_mode(&mut self) {
         self.history_index = None;
+    }
+
+    fn reset_action_state(&mut self) {
+        self.preferred_visual_col = None;
+        self.last_action = LastAction::Other;
+        self.last_yank_len = None;
     }
 
     fn insert_text_internal(&mut self, text: &str) {

--- a/crates/rho-tui/src/overlay.rs
+++ b/crates/rho-tui/src/overlay.rs
@@ -297,15 +297,19 @@ fn resolve_overlay_rect_from_content(
 }
 
 fn max_content_width(lines: &[Line<'_>]) -> u16 {
-    let mut max_width = 1u16;
-    for line in lines {
-        let width = u16::try_from(line.spans.iter().fold(0usize, |sum, span| {
-            sum.saturating_add(span.content.chars().count())
-        }))
-        .unwrap_or(u16::MAX);
-        max_width = max_width.max(width);
-    }
-    max_width
+    lines
+        .iter()
+        .map(|line| {
+            u16::try_from(
+                line.spans
+                    .iter()
+                    .map(|span| span.content.chars().count())
+                    .sum::<usize>(),
+            )
+            .unwrap_or(u16::MAX)
+        })
+        .max()
+        .unwrap_or(1)
 }
 
 fn anchor_row(anchor: OverlayAnchor, available_height: u16, overlay_height: u16) -> u16 {

--- a/crates/rho-tui/src/widgets/markdown.rs
+++ b/crates/rho-tui/src/widgets/markdown.rs
@@ -108,20 +108,12 @@ pub fn render_markdown(markdown: &str, width: u16, theme: &UiTheme) -> Vec<Line<
 }
 
 fn parse_heading(line: &str) -> Option<&str> {
-    let hash_count = line.chars().take_while(|ch| *ch == '#').count();
+    let trimmed = line.as_bytes();
+    let hash_count = trimmed.iter().take_while(|&&b| b == b'#').count();
     if hash_count == 0 || hash_count > 6 {
         return None;
     }
-    let mut chars = line.chars();
-    for _ in 0..hash_count {
-        let _ = chars.next();
-    }
-
-    if !matches!(chars.next(), Some(' ')) {
-        return None;
-    }
-
-    Some(chars.as_str())
+    line.get(hash_count..)?.strip_prefix(' ')
 }
 
 fn parse_markdown_image(line: &str) -> Option<(&str, &str)> {

--- a/crates/rho-tui/src/widgets/spacer.rs
+++ b/crates/rho-tui/src/widgets/spacer.rs
@@ -1,5 +1,5 @@
 use ratatui::text::Line;
 
-pub fn spacer_lines(lines: usize) -> Vec<Line<'static>> {
-    (0..lines).map(|_| Line::from(String::new())).collect()
+pub fn spacer_lines(count: usize) -> Vec<Line<'static>> {
+    vec![Line::from(String::new()); count]
 }


### PR DESCRIPTION
## Summary

Identified and addressed several simplification opportunities across the codebase. Net result: **-37 lines** (41 added, 78 removed).

### Changes

- **`editor.rs`**: Extract repetitive 3-line state reset block into `reset_action_state()` helper — was duplicated across 12 methods
- **`editor.rs`**: Deduplicate `backspace()` by delegating to the existing `backspace_without_undo()`
- **`runtime.rs`**: Inline trivial `max_tool_iterations_error` wrapper at its single call site
- **`overlay.rs`**: Rewrite `max_content_width` from manual loop to iterator chain
- **`markdown.rs`**: Simplify `parse_heading` using byte scanning and `strip_prefix`
- **`spacer.rs`**: Replace `(0..n).map(...).collect()` with `vec![...; n]`

### Not included

Considered extracting the duplicated streaming loop between OpenAI/Anthropic providers, but deferred — the `async_stream::try_stream!` macro's `yield` semantics and generic `CompletionStream<R>` type make clean extraction add more complexity than it removes. The two provider files are small and the duplication is tolerable.

### Validation

- `cargo +nightly fmt --all --check` ✅
- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace` ✅ (55/55 tests pass)