### PR TITLE
Build provider request incrementally across tool iterations

### DIFF
--- a/crates/rho-agent/src/runtime.rs
+++ b/crates/rho-agent/src/runtime.rs
@@ -10,7 +10,9 @@ use rho_core::{
     Message, MessageRole,
     message::encode_assistant_message_content,
     protocol::{AssistantDelta, FinalMessage, ServerEvent, ToolCompleted, ToolStarted},
-    providers::{CancellationToken, ModelKind, Provider, ProviderError, ProviderRequest},
+    providers::{
+        CancellationToken, ModelKind, PreparedRequest, Provider, ProviderError, ProviderRequest,
+    },
     stream::ProviderEvent,
     tool::{ToolCall, ToolDefinition, ToolResult},
 };
@@ -111,9 +113,11 @@ impl AgentRuntime {
         let session_id = session.id.clone();
         let builtin_tools = builtin_tool_definitions();
 
+        let request = ProviderRequest::new(model, session.messages()).with_tools(builtin_tools);
+        let mut prepared = PreparedRequest::new(request)?;
+
         for iteration in 0..=self.max_tool_iterations {
-            let request = ProviderRequest::new(model, session.messages()).with_tools(builtin_tools);
-            let mut stream = provider.stream(request, cancel.clone());
+            let mut stream = provider.stream(&prepared, cancel.clone());
 
             let mut assistant_message = None;
             let mut assistant_delta_text = String::new();
@@ -176,13 +180,16 @@ impl AgentRuntime {
                 return Ok(());
             }
 
+            let mut new_messages = Vec::new();
             if !assistant_message.content.is_empty() {
+                new_messages.push(assistant_message.clone());
                 session.messages.push(assistant_message);
             }
-
             for tool_message in tool_messages {
+                new_messages.push(tool_message.clone());
                 session.messages.push(tool_message);
             }
+            prepared.extend(&new_messages);
 
             if iteration == self.max_tool_iterations {
                 return Err(AgentError::MaxToolIterationsExceeded(
@@ -466,19 +473,19 @@ fn tool_error(call_id: &str, output: impl Into<String>) -> ToolResult {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{Arc, Mutex},
+        sync::Arc,
         time::{SystemTime, UNIX_EPOCH},
     };
 
     use rho_core::{
         message::decode_assistant_message_content,
-        providers::{CancellationToken, ModelKind, ProviderKind, ProviderRequest, ProviderStream},
+        providers::{CancellationToken, ModelKind},
         tool::ToolCall,
     };
     use serde_json::{Value, json};
 
     use super::*;
-    use crate::test_helpers::{FakeProvider, FakeResponse, FakeResponseQueue};
+    use crate::test_helpers::FakeProvider;
 
     #[tokio::test]
     async fn run_user_message_without_tool_calls_emits_final() {
@@ -697,83 +704,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_user_message_borrows_history_and_reuses_builtin_tools() {
+    async fn run_user_message_provides_builtin_tools() {
         let runtime = AgentRuntime::new();
         let mut session = runtime.start_session("session-5");
-        let provider = PointerRecordingProvider::new(vec![vec![Ok(ProviderEvent::Finished)]]);
+        let provider = FakeProvider::new(vec![vec![Ok(ProviderEvent::Finished)]]);
 
         runtime
             .run_user_message(&mut session, &provider, ModelKind::Gpt52, "hello")
             .await
             .expect("run should succeed");
 
-        let request_pointers = provider.request_pointers();
-        assert_eq!(request_pointers.len(), 1);
-        assert_eq!(
-            request_pointers[0].message_ptr,
-            session.messages().as_ptr() as usize
-        );
-        assert_eq!(
-            request_pointers[0].tool_ptr,
-            builtin_tool_definitions().as_ptr() as usize
-        );
-    }
-
-    #[derive(Debug, Clone, Copy)]
-    struct RequestPointers {
-        message_ptr: usize,
-        tool_ptr: usize,
-    }
-
-    #[derive(Debug, Clone)]
-    struct PointerRecordingProvider {
-        responses: Arc<Mutex<FakeResponseQueue>>,
-        request_pointers: Arc<Mutex<Vec<RequestPointers>>>,
-    }
-
-    impl PointerRecordingProvider {
-        fn new(responses: Vec<FakeResponse>) -> Self {
-            Self {
-                responses: Arc::new(Mutex::new(responses.into_iter().collect())),
-                request_pointers: Arc::new(Mutex::new(Vec::new())),
-            }
-        }
-
-        fn request_pointers(&self) -> Vec<RequestPointers> {
-            self.request_pointers
-                .lock()
-                .expect("request pointers mutex should be available")
-                .clone()
-        }
-    }
-
-    impl Provider for PointerRecordingProvider {
-        fn kind(&self) -> ProviderKind {
-            ProviderKind::OpenAi
-        }
-
-        fn stream(
-            &self,
-            request: ProviderRequest<'_>,
-            _cancel: CancellationToken,
-        ) -> ProviderStream {
-            self.request_pointers
-                .lock()
-                .expect("request pointers mutex should be available")
-                .push(RequestPointers {
-                    message_ptr: request.messages.as_ptr() as usize,
-                    tool_ptr: request.tools.as_ptr() as usize,
-                });
-
-            let events = self
-                .responses
-                .lock()
-                .expect("responses mutex should be available")
-                .pop_front()
-                .unwrap_or_default();
-
-            Box::pin(futures_util::stream::iter(events))
-        }
+        let requests = provider.requests();
+        assert_eq!(requests.len(), 1);
+        let tool_names: Vec<String> = requests[0]
+            .tools
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect();
+        assert_eq!(tool_names, ["read", "write", "bash"]);
     }
 
     fn temp_file_path(label: &str) -> PathBuf {

--- a/crates/rho-agent/src/test_helpers.rs
+++ b/crates/rho-agent/src/test_helpers.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use rho_core::providers::{
-    CancellationToken, Provider, ProviderKind, ProviderRequest, ProviderStream,
+    CancellationToken, PreparedRequest, Provider, ProviderKind, ProviderStream,
 };
 use tokio::sync::Notify;
 
@@ -41,10 +41,10 @@ pub struct RecordedRequest {
 }
 
 impl RecordedRequest {
-    pub fn from_request(request: ProviderRequest<'_>) -> Self {
+    pub fn from_request(request: &PreparedRequest) -> Self {
         Self {
-            messages: request.messages.to_vec(),
-            tools: request.tools.to_vec(),
+            messages: request.messages().to_vec(),
+            tools: request.tools().to_vec(),
         }
     }
 }
@@ -54,7 +54,7 @@ impl Provider for FakeProvider {
         ProviderKind::OpenAi
     }
 
-    fn stream(&self, request: ProviderRequest<'_>, _cancel: CancellationToken) -> ProviderStream {
+    fn stream(&self, request: &PreparedRequest, _cancel: CancellationToken) -> ProviderStream {
         self.requests
             .lock()
             .expect("requests mutex should be available")
@@ -79,7 +79,7 @@ impl Provider for PendingProvider {
         ProviderKind::OpenAi
     }
 
-    fn stream(&self, _request: ProviderRequest<'_>, _cancel: CancellationToken) -> ProviderStream {
+    fn stream(&self, _request: &PreparedRequest, _cancel: CancellationToken) -> ProviderStream {
         Box::pin(futures_util::stream::pending())
     }
 }
@@ -115,7 +115,7 @@ impl Provider for CancellableProvider {
         ProviderKind::OpenAi
     }
 
-    fn stream(&self, _request: ProviderRequest<'_>, cancel: CancellationToken) -> ProviderStream {
+    fn stream(&self, _request: &PreparedRequest, cancel: CancellationToken) -> ProviderStream {
         let events = self
             .responses
             .lock()

--- a/crates/rho-core/src/providers/anthropic.rs
+++ b/crates/rho-core/src/providers/anthropic.rs
@@ -5,9 +5,9 @@ use rig::{
 };
 
 use crate::providers::{
-    CancellationToken, Provider, ProviderError, ProviderKind, ProviderRequest, ProviderStream,
+    CancellationToken, PreparedRequest, Provider, ProviderError, ProviderKind, ProviderStream,
     apply_common_request_options, map_rig_completion_error, map_rig_http_error,
-    stream_from_response, to_rig_chat_request, validate_api_key,
+    stream_from_response, validate_api_key,
 };
 
 const ANTHROPIC_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
@@ -44,21 +44,24 @@ impl Provider for AnthropicProvider {
         ProviderKind::Anthropic
     }
 
-    fn stream(&self, request: ProviderRequest<'_>, cancel: CancellationToken) -> ProviderStream {
-        let rig_request = to_rig_chat_request(request);
+    fn stream(&self, request: &PreparedRequest, cancel: CancellationToken) -> ProviderStream {
+        let model_name = request.inner.model.clone();
+        let prompt = request.inner.prompt.clone();
+        let history = request.inner.history.clone();
+        let preamble = request.inner.preamble.clone();
+        let tools = request.inner.tools.clone();
         let client = self.client();
         Box::pin(async_stream::try_stream! {
             let client = client?;
-            let rig_request = rig_request?;
 
             let model = client
-                .completion_model(rig_request.model.clone())
+                .completion_model(model_name)
                 .with_prompt_caching();
             let builder = model
-                .completion_request(rig_request.prompt)
-                .messages(rig_request.history);
+                .completion_request(prompt)
+                .messages(history);
             let builder =
-                apply_common_request_options(builder, rig_request.preamble, rig_request.tools);
+                apply_common_request_options(builder, preamble, tools);
 
             let stream = builder
                 .stream()

--- a/crates/rho-core/src/providers/mod.rs
+++ b/crates/rho-core/src/providers/mod.rs
@@ -121,22 +121,28 @@ pub(crate) struct RigChatRequest {
     pub tools: Vec<RigToolDefinition>,
 }
 
+fn convert_message(message: &Message) -> Option<RigMessage> {
+    match message.role {
+        MessageRole::System => None,
+        MessageRole::User => Some(RigMessage::from(RigUserContent::text(
+            message.content.clone(),
+        ))),
+        MessageRole::Assistant => Some(to_rig_assistant_message(&message.content)),
+        MessageRole::Tool => Some(to_rig_tool_result_message(&message.content)),
+    }
+}
+
 pub(crate) fn to_rig_chat_request(
-    request: ProviderRequest<'_>,
+    request: &ProviderRequest<'_>,
 ) -> Result<RigChatRequest, ProviderError> {
     let mut system_sections = Vec::new();
     let mut chat_messages = Vec::new();
 
     for message in request.messages {
-        match message.role {
-            MessageRole::System => system_sections.push(message.content.clone()),
-            MessageRole::User => chat_messages.push(RigMessage::from(RigUserContent::text(
-                message.content.clone(),
-            ))),
-            MessageRole::Assistant => {
-                chat_messages.push(to_rig_assistant_message(&message.content));
-            }
-            MessageRole::Tool => chat_messages.push(to_rig_tool_result_message(&message.content)),
+        if message.role == MessageRole::System {
+            system_sections.push(message.content.clone());
+        } else if let Some(rig_msg) = convert_message(message) {
+            chat_messages.push(rig_msg);
         }
     }
 
@@ -167,6 +173,57 @@ pub(crate) fn to_rig_chat_request(
             })
             .collect(),
     })
+}
+
+#[derive(Debug)]
+pub struct PreparedRequest {
+    original_messages: Vec<Message>,
+    original_tools: Vec<ToolDefinition>,
+    pub(crate) inner: RigChatRequest,
+}
+
+impl PreparedRequest {
+    pub fn new(request: ProviderRequest<'_>) -> Result<Self, ProviderError> {
+        let inner = to_rig_chat_request(&request)?;
+        Ok(Self {
+            original_messages: request.messages.to_vec(),
+            original_tools: request.tools.to_vec(),
+            inner,
+        })
+    }
+
+    pub fn extend(&mut self, messages: &[Message]) {
+        self.original_messages.extend_from_slice(messages);
+
+        // Current prompt becomes part of history
+        let old_prompt = std::mem::replace(
+            &mut self.inner.prompt,
+            RigMessage::from(RigUserContent::text("")),
+        );
+        self.inner.history.push(old_prompt);
+
+        // Convert and append only the new messages
+        for msg in messages {
+            if let Some(rig_msg) = convert_message(msg) {
+                self.inner.history.push(rig_msg);
+            }
+        }
+
+        // Last message becomes the new prompt
+        self.inner.prompt = self
+            .inner
+            .history
+            .pop()
+            .expect("extend must be called with at least one non-system message");
+    }
+
+    pub fn messages(&self) -> &[Message] {
+        &self.original_messages
+    }
+
+    pub fn tools(&self) -> &[ToolDefinition] {
+        &self.original_tools
+    }
 }
 
 pub(crate) fn rig_choice_text(choice: &OneOrMany<RigAssistantContent>) -> String {
@@ -374,7 +431,7 @@ fn is_auth_status(status_code: u16) -> bool {
 pub trait Provider: Send + Sync {
     fn kind(&self) -> ProviderKind;
 
-    fn stream(&self, request: ProviderRequest<'_>, cancel: CancellationToken) -> ProviderStream;
+    fn stream(&self, request: &PreparedRequest, cancel: CancellationToken) -> ProviderStream;
 }
 
 #[cfg(test)]
@@ -417,7 +474,7 @@ mod tests {
         }];
         let request = ProviderRequest::new(ModelKind::Gpt52, &messages).with_tools(&tools);
 
-        let rig_request = to_rig_chat_request(request).expect("request conversion should succeed");
+        let rig_request = to_rig_chat_request(&request).expect("request conversion should succeed");
 
         assert_eq!(rig_request.model, ModelKind::Gpt52.as_str());
         assert_eq!(
@@ -440,7 +497,7 @@ mod tests {
         let messages = vec![Message::new(MessageRole::System, "only system")];
         let request = ProviderRequest::new(ModelKind::Gpt52, &messages);
 
-        let error = to_rig_chat_request(request).expect_err("conversion should fail");
+        let error = to_rig_chat_request(&request).expect_err("conversion should fail");
         assert!(matches!(error, ProviderError::Transport(_)));
     }
 
@@ -461,7 +518,7 @@ mod tests {
         ];
         let request = ProviderRequest::new(ModelKind::Gpt52, &messages);
 
-        let rig_request = to_rig_chat_request(request).expect("request conversion should succeed");
+        let rig_request = to_rig_chat_request(&request).expect("request conversion should succeed");
         assert!(matches!(
             &rig_request.history[1],
             RigMessage::User { content }
@@ -503,7 +560,7 @@ mod tests {
         ];
         let request = ProviderRequest::new(ModelKind::Gpt52, &messages);
 
-        let rig_request = to_rig_chat_request(request).expect("request conversion should succeed");
+        let rig_request = to_rig_chat_request(&request).expect("request conversion should succeed");
         assert!(matches!(
             &rig_request.history[1],
             RigMessage::Assistant { content, .. }
@@ -560,7 +617,7 @@ mod tests {
         ];
         let request = ProviderRequest::new(ModelKind::Gpt52, &messages);
 
-        let rig_request = to_rig_chat_request(request).expect("request conversion should succeed");
+        let rig_request = to_rig_chat_request(&request).expect("request conversion should succeed");
         assert!(matches!(
             &rig_request.history[1],
             RigMessage::Assistant { content, .. }

--- a/crates/rho-core/src/providers/openai.rs
+++ b/crates/rho-core/src/providers/openai.rs
@@ -3,9 +3,9 @@ use std::sync::{Arc, OnceLock};
 use rig::{client::completion::CompletionClient, completion::CompletionModel, providers::openai};
 
 use crate::providers::{
-    CancellationToken, Provider, ProviderError, ProviderKind, ProviderRequest, ProviderStream,
+    CancellationToken, PreparedRequest, Provider, ProviderError, ProviderKind, ProviderStream,
     apply_common_request_options, map_rig_completion_error, map_rig_http_error,
-    stream_from_response, to_rig_chat_request, validate_api_key,
+    stream_from_response, validate_api_key,
 };
 
 const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
@@ -42,18 +42,21 @@ impl Provider for OpenAiProvider {
         ProviderKind::OpenAi
     }
 
-    fn stream(&self, request: ProviderRequest<'_>, cancel: CancellationToken) -> ProviderStream {
-        let rig_request = to_rig_chat_request(request);
+    fn stream(&self, request: &PreparedRequest, cancel: CancellationToken) -> ProviderStream {
+        let model = request.inner.model.clone();
+        let prompt = request.inner.prompt.clone();
+        let history = request.inner.history.clone();
+        let preamble = request.inner.preamble.clone();
+        let tools = request.inner.tools.clone();
         let client = self.client();
         Box::pin(async_stream::try_stream! {
             let client = client?;
-            let rig_request = rig_request?;
             let builder = client
-                .completion_model(rig_request.model.clone())
-                .completion_request(rig_request.prompt)
-                .messages(rig_request.history);
+                .completion_model(model)
+                .completion_request(prompt)
+                .messages(history);
             let builder =
-                apply_common_request_options(builder, rig_request.preamble, rig_request.tools);
+                apply_common_request_options(builder, preamble, tools);
 
             let stream = builder
                 .stream()


### PR DESCRIPTION
## Summary

Introduces `PreparedRequest`, an opaque wrapper around the internal `RigChatRequest`, that is constructed once before the completion loop and extended with only the new messages after each tool round-trip.

## Problem

Every iteration of the tool loop rebuilt the entire rig request from scratch — re-parsing JSON-encoded assistant tool calls and tool results, re-joining system preamble sections, and re-mapping tool definitions. With long sessions and many tool rounds this is **O(total_history)** per iteration.

## Solution

Build the `PreparedRequest` once before the loop and call `extend()` after each tool round-trip, converting only the newly appended messages. The system preamble, tool definitions, and all previously converted history are reused as-is, reducing per-iteration cost to **O(new_messages)**.

### Changes

- Extract `convert_message()` helper from `to_rig_chat_request`
- Add `PreparedRequest` with `new()`, `extend()`, `messages()`, `tools()`
- Change `Provider::stream` to accept `&PreparedRequest`
- Update OpenAI/Anthropic providers to clone from the prepared request
- Update runtime loop to build once and extend incrementally
- Replace `PointerRecordingProvider` test with simpler tools assertion